### PR TITLE
feat: #Https and Security headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 server/public
-
+*.pem
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commitizen": "^4.2.4",
         "cz-conventional-changelog": "^3.3.0",
         "dotenv": "^16.0.1",
+        "helmet": "^5.1.0",
         "husky": "^8.0.1",
         "lint-staged": "^12.4.1",
         "morgan": "^1.10.0",
@@ -3442,6 +3443,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.1.0.tgz",
+      "integrity": "sha512-klsunXs8rgNSZoaUrNeuCiWUxyc+wzucnEnFejUg3/A+CaF589k9qepLZZ1Jehnzig7YbD4hEuscGXuBY3fq+g==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hexoid": {
@@ -10332,6 +10341,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
+    },
+    "helmet": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.1.0.tgz",
+      "integrity": "sha512-klsunXs8rgNSZoaUrNeuCiWUxyc+wzucnEnFejUg3/A+CaF589k9qepLZZ1Jehnzig7YbD4hEuscGXuBY3fq+g=="
     },
     "hexoid": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",
     "dotenv": "^16.0.1",
+    "helmet": "^5.1.0",
     "husky": "^8.0.1",
     "lint-staged": "^12.4.1",
     "morgan": "^1.10.0",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const express = require('express');
+const helmet = require('helmet');
 const morgan = require('morgan');
 const cors = require('cors');
 const v1Router = require('./routes/apis/v1');
@@ -8,6 +9,7 @@ const app = express();
 /**
  * Middlewares
  */
+app.use(helmet());
 app.use(express.json());
 app.use(cors());
 app.use(morgan('combined'));

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,9 +1,17 @@
-const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
 require('dotenv').config();
 const app = require('./app');
 const { mongoConnect } = require('./services/mongo');
 
-const server = http.createServer(app);
+const server = https.createServer(
+  {
+    key: fs.readFileSync(path.join(__dirname, '..', 'key.pem')),
+    cert: fs.readFileSync(path.join(__dirname, '..', 'cert.pem')),
+  },
+  app
+);
 
 const PORT = process.env.PORT || 5000;
 


### PR DESCRIPTION
Configured server to use https instead of http. Used self-signed certificates generated using
openssl. Also added helmet() middleware to provide extra layer of security using security headers in
the API responses.
